### PR TITLE
add execv

### DIFF
--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -149,6 +149,20 @@ public:
         return(rep);
     }
 
+    SEXP execv(std::vector<std::string> cmd) {
+        const char* cmdv[cmd.size()];
+        size_t cmdlen[cmd.size()];
+        for (int i=0; i < cmd.size(); ++i) {
+          cmdv[i] = cmd[i].c_str();
+          cmdlen[i] = cmd[i].size();
+        }
+
+        redisReply *reply = static_cast<redisReply*>(redisCommandArgv(prc_, cmd.size(), cmdv, cmdlen));
+        SEXP rep = extract_reply(reply);
+        freeReplyObject(reply);
+        return(rep);
+    }
+
 
     // redis set -- serializes to R internal format
     std::string set(std::string key, SEXP s) {
@@ -491,6 +505,7 @@ RCPP_MODULE(Redis) {
         .constructor<std::string, int>("constructor with host and port")  
 
         .method("exec", &Redis::exec,  "execute given redis command and arguments")
+        .method("execv", &Redis::execv,  "execute given a vector of redis command and arguments")
 
         .method("set",  &Redis::set,   "runs 'SET key object', serializes internally")
         .method("get",  &Redis::get,   "runs 'GET key', deserializes internally")


### PR DESCRIPTION
[ If I tag @armstrtw here, will he get notified? ]

This patch solves Whit's problem as reported here: http://lists.r-forge.r-project.org/pipermail/rcpp-devel/2014-June/007766.html

Example:

``` R
> redis$exec("SMEMBERS hats")
list()
> redis$exec("SADD hats 'big hat'") ## quoting doesn't work
[1] 2
> redis$exec("SMEMBERS hats")
[[1]]
[1] "hat'"

[[2]]
[1] "'big"

> redis$execv(c("SADD", "hats", "little hat")) ## vectorizing does work
[1] 1
> redis$exec("SMEMBERS hats")
[[1]]
[1] "little hat"

[[2]]
[1] "hat'"

[[3]]
[1] "'big"
```
