### PR TITLE
Tests of new list methods; list methods return NULL if empty / non-existent

### DIFF
--- a/inst/tests/runit.listTests.R
+++ b/inst/tests/runit.listTests.R
@@ -1,0 +1,59 @@
+test_01_setup <- function() {
+    suppressMessages(library(RcppRedis))
+    redis <<- new(Redis)
+
+    exampleNumericElement <<- 1.0
+    exampleCharElement <<- "a"
+    key <<- "RcppRedis:test:mylist"
+    redis$exec(paste("del", key))
+}
+
+test_02_lpush <- function() {
+    # add example elements to the list
+    n1 <- redis$lpush(key, exampleNumericElement)
+    n2 <- redis$lpush(key, exampleCharElement)
+    checkEquals(n1, 1)
+    checkEquals(n2, 2)
+}
+
+test_03_lpop <- function() {
+    # remove example elements from the list
+    res1 <- redis$lpop(key)
+    res2 <- redis$lpop(key)
+    checkEquals(res1, exampleCharElement)
+    checkEquals(res2, exampleNumericElement)
+}
+
+test_04_lpopnull <- function() {
+    # try to lpop beyond list extent
+    res <- redis$rpop(key)
+    checkEquals(res, NULL)
+}
+
+test_05_rpush <- function() {
+    # add example elements to the list
+    n1 <- redis$rpush(key, exampleNumericElement)
+    n2 <- redis$rpush(key, exampleCharElement)
+    checkEquals(n1, 1)
+    checkEquals(n2, 2)
+}
+
+test_06_rpop <- function() {
+    # remove example elements from the list
+    res1 <- redis$rpop(key)
+    res2 <- redis$rpop(key)
+    checkEquals(res1, exampleCharElement)
+    checkEquals(res2, exampleNumericElement)
+}
+
+test_07_rpopnull <- function() {
+    # try to rpop beyond list extent
+    res <- redis$rpop(key)
+    checkEquals(res, NULL)
+}
+
+test_08_cleanup <- function() {
+    ## delete set
+    n <- redis$exec(paste("del", key))
+    checkEquals(n, 1)
+}

--- a/inst/tests/runit.listTests.R
+++ b/inst/tests/runit.listTests.R
@@ -53,7 +53,7 @@ test_07_rpopnull <- function() {
 }
 
 test_08_cleanup <- function() {
-    ## delete set
+    ## delete key
     n <- redis$exec(paste("del", key))
-    checkEquals(n, 1)
+    checkEquals(n, 0)
 }

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -64,6 +64,8 @@ private:
             if (reply->type == REDIS_REPLY_ERROR) {
                 freeReplyObject(reply);
                 Rcpp::stop(std::string("Redis authentication error."));
+            } else {
+                freeReplyObject(reply);
             }
         }
     }

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -353,7 +353,7 @@ public:
     }
     
     // redis "prepend to list" -- with R serialization
-    std::string lpush(std::string key, SEXP s) {
+    SEXP lpush(std::string key, SEXP s) {
         
         // if raw, use as is else serialize to raw
         Rcpp::RawVector x = (TYPEOF(s) == RAWSXP) ? s : serializeToRaw(s);
@@ -363,13 +363,14 @@ public:
             static_cast<redisReply*>(redisCommand(prc_, "LPUSH %s %b", 
                                                   key.c_str(), x.begin(), x.size()*szdb));
 
-        std::string res = "";
+        
+        SEXP rep = extract_reply(reply);
         freeReplyObject(reply);
-        return(res);
+        return(rep);
     }
   
       // redis "append to list" -- with R serialization
-    std::string rpush(std::string key, SEXP s) {
+    SEXP rpush(std::string key, SEXP s) {
         
         // if raw, use as is else serialize to raw
         Rcpp::RawVector x = (TYPEOF(s) == RAWSXP) ? s : serializeToRaw(s);
@@ -379,9 +380,9 @@ public:
             static_cast<redisReply*>(redisCommand(prc_, "RPUSH %s %b", 
                                                   key.c_str(), x.begin(), x.size()*szdb));
 
-        std::string res = "";
+        SEXP rep = extract_reply(reply);
         freeReplyObject(reply);
-        return(res);
+        return(rep);
     }
   
   

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -328,27 +328,42 @@ public:
     // Some "R-serialization" functions below
     // redis "lpop from" -- with R serialization
     SEXP lpop(std::string key) {
+        SEXP obj;
+        std::string res;
+        
         redisReply *reply = 
             static_cast<redisReply*>(redisCommand(prc_, "LPOP %s", key.c_str()));
 
-        int nc = reply->len;
-        Rcpp::RawVector res(nc);
-        memcpy(res.begin(), reply->str, nc);
-        freeReplyObject(reply);
-        SEXP obj = unserializeFromRaw(res);
+        if (replyTypeToInteger(reply) == replyNil_t) {
+            obj = R_NilValue;
+        } else {
+            checkReplyType(reply, replyString_t); // ensure we got string
+            int nc = reply->len;
+            Rcpp::RawVector res(nc);
+            memcpy(res.begin(), reply->str, nc);
+            obj = unserializeFromRaw(res);
+        }
+        
         return(obj);
     }
   
   // redis "rpop from" -- with R serialization
     SEXP rpop(std::string key) {
+        SEXP obj;
+        std::string res;
         redisReply *reply = 
             static_cast<redisReply*>(redisCommand(prc_, "RPOP %s", key.c_str()));
 
-        int nc = reply->len;
-        Rcpp::RawVector res(nc);
-        memcpy(res.begin(), reply->str, nc);
-        freeReplyObject(reply);
-        SEXP obj = unserializeFromRaw(res);
+        if (replyTypeToInteger(reply) == replyNil_t) {
+            obj = R_NilValue;
+        } else {
+            checkReplyType(reply, replyString_t); // ensure we got string
+            int nc = reply->len;
+            Rcpp::RawVector res(nc);
+            memcpy(res.begin(), reply->str, nc);
+            obj = unserializeFromRaw(res);
+        }
+        
         return(obj);
     }
     


### PR DESCRIPTION
This PR:
1. Adds tests for tests for lpush, rpush, lpop, and rpop
2. Updates lpop and rpop such that if the list is empty or non-existent the return is NULL
3. Updates lpush and rpush so they return the number of items in the list, consistent with the return from the redis server

My apologies for the piecemeal contribution and appreciation for @eddelbuettel 's patience and guidance.