### PR TITLE
Windows: use libhiredis 1.0.0 + ucrt support

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,13 +1,12 @@
 ## -*- mode: Makefile; -*-
 ##
-## The LIB_HIREDIS variable points to the library which was kindly
-## built by John Buonagurio, and the -DSTRICT_R_HEADERS flag avoids a
-## conflict with macro redefinitions
-##
-PKG_CPPFLAGS = -I${LIB_HIREDIS}/include -DSTRICT_R_HEADERS
-##
-PKG_LIBS = ${LIB_HIREDIS}/lib/${R_ARCH}/libhiredis.a -lws2_32
+RWINLIB=../windows/hiredis-1.0.0
+PKG_CPPFLAGS = -I${RWINLIB}/include -DSTRICT_R_HEADERS
+PKG_LIBS = -L${RWINLIB}/lib${R_ARCH}${CRT} -lhiredis -lws2_32
 
 CXX_STD = CXX11
 
+all: winlibs
 
+winlibs:
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,7 @@
+if (!file.exists("../windows/hiredis-1.0.0/include/hiredis/hiredis.h")) {
+  if (getRversion() < "3.3.0") setInternet2()
+  download.file("https://github.com/rwinlib/hiredis/archive/v1.0.0.zip", "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
This downloads a suitable version of libhiredis for WIndows using the standard mechanics. 
Once merged, Windows binaries for RcppRedis will become available on e.g. https://eddelbuettel.r-universe.dev