### PR TITLE
Add pubsub from rredis

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,15 +1,27 @@
+2021-12-31  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/libsock.c (_OPEN_FD, _SOCK_NAGLE): Register as symbols, but use
+	not-exported-by-default name starting with an underscore
+	* src/init.c: Idem
+
+
 2021-12-30  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version
 
 	* R/pubsub.R: Imported from packaged 'rredis' to support pub/sub
 	* R/internal.R: Idem
+	* R/rredis-misc.R: Idem
 	* src/libsock.c: Idem
 	* man/redisPublish.Rd: Documentation for pub/sub and support
 	* man/redisSubscribe.Rd: Idem
 	* man/redisUnsubscribe.Rd: Idem
 	* man/redisMonitorChannels.Rd: Idem
 	* man/redisCmd.Rd: Idem
+        * man/redisAuth.Rd: Idem
+        * man/redisClose.Rd: Idem
+        * man/redisConnect.Rd: Idem
+        * man/redisZAdd.Rd: Idem
 	* tests/pubsub.R: Idem
 
 	* DESCRIPTION: Bryan Lewis is now a co-author of the package
@@ -17,6 +29,9 @@
 	* LICENSE: Added explicit license statement for added files which
 	remain under Apache License 2.0 while the remainder of the package
 	as well as the aggregation continues to be licensed under GPL (>= 2)
+
+	* src/Redis.cpp: Use C++11 instead of lexical_cast for double -> string
+	* DESCRIPTION: Remove LinkingTo: on BH
 
 2021-12-18  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2021-12-30  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/pubsub.R: Imported from packaged 'rredis' to support pub/sub
+	* R/internal.R: Idem
+	* src/libsock.c: Idem
+	* man/redisPublish.Rd: Documentation for pub/sub and support
+	* man/redisSubscribe.Rd: Idem
+	* man/redisUnsubscribe.Rd: Idem
+	* man/redisMonitorChannels.Rd: Idem
+	* man/redisCmd.Rd: Idem
+
+	* DESCRIPTION: Bryan Lewis is now a co-author of the package
+
 2021-12-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Remove unused continuous integration artifact and badge

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,13 +10,14 @@
 	* man/redisUnsubscribe.Rd: Idem
 	* man/redisMonitorChannels.Rd: Idem
 	* man/redisCmd.Rd: Idem
+	* tests/pubsub.R: Idem
 
 	* DESCRIPTION: Bryan Lewis is now a co-author of the package
 
 	* LICENSE: Added explicit license statement for added files which
 	remain under Apache License 2.0 while the remainder of the package
 	as well as the aggregation continues to be licensed under GPL (>= 2)
-	
+
 2021-12-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Remove unused continuous integration artifact and badge

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2021-12-30  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+
 	* R/pubsub.R: Imported from packaged 'rredis' to support pub/sub
 	* R/internal.R: Idem
 	* src/libsock.c: Idem
@@ -11,6 +13,10 @@
 
 	* DESCRIPTION: Bryan Lewis is now a co-author of the package
 
+	* LICENSE: Added explicit license statement for added files which
+	remain under Apache License 2.0 while the remainder of the package
+	as well as the aggregation continues to be licensed under GPL (>= 2)
+	
 2021-12-18  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Remove unused continuous integration artifact and badge

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RcppRedis
 Type: Package
 Title: 'Rcpp' Bindings for 'Redis' using the 'hiredis' Library
-Version: 0.1.11
-Date: 2021-06-26
+Version: 0.1.11.1
+Date: 2021-12-30
 Author: Dirk Eddelbuettel and Bryan W. Lewis
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Connection to the 'Redis' key/value store using the
@@ -15,7 +15,7 @@ SystemRequirements: An available hiredis library (eg via package
  preferred but otherwise built on demand.
 URL: https://github.com/eddelbuettel/rcppredis, https://dirk.eddelbuettel.com/code/rcpp.redis.html
 BugReports: https://github.com/eddelbuettel/rcppredis/issues
-License: GPL (>= 2)
+License: GPL-2 | GPL-3 | Apache License (>= 2)
 Imports: methods, Rcpp (>= 0.11.0), RApiSerialize
 LinkingTo: Rcpp, RApiSerialize
 Suggests: RcppMsgPack, rredis, tinytest

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,11 +3,12 @@ Type: Package
 Title: 'Rcpp' Bindings for 'Redis' using the 'hiredis' Library
 Version: 0.1.11
 Date: 2021-06-26
-Author: Dirk Eddelbuettel
+Author: Dirk Eddelbuettel and Bryan W. Lewis
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Connection to the 'Redis' key/value store using the
  C-language client library 'hiredis' (included as a fallback) with
- 'MsgPack' encoding provided via 'RcppMsgPack' headers.
+ 'MsgPack' encoding provided via 'RcppMsgPack' headers. It now also
+ includes the pub/sub functions from the 'rredis' package.
 SystemRequirements: An available hiredis library (eg via package
  libhiredis-dev on Debian/Ubuntu, hiredis-devel on Fedora/RedHat, or
  directly from source from <https://github.com/redis/hiredis>) is

--- a/LICENSE
+++ b/LICENSE
@@ -16,6 +16,7 @@ The files
   man/redisUnsubscribe.Rd
   man/redisMonitorChannels.Rd
   man/redisCmd.Rd
+  tests/pubsub.R
 
 are included from the rredis package, and have been licensed under the
 Apache License, Version 2, and remain under the Apache License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,43 @@
+
+The RcppRedis package is released under the GNU GPL, Version 2 or later.
+
+This covers all files in the package, as well as the package
+aggregation, with the exception of the files listed explicitly below
+which were already licensed under the Apache License, Version 2.0, and
+continue to be licensed under the Apache License, Version 2.0.
+
+The files
+
+  R/pubsub.R
+  R/internal.R
+  src/libsock.c
+  man/redisPublish.Rd
+  man/redisSubscribe.Rd
+  man/redisUnsubscribe.Rd
+  man/redisMonitorChannels.Rd
+  man/redisCmd.Rd
+
+are included from the rredis package, and have been licensed under the
+Apache License, Version 2, and remain under the Apache License.
+
+
+The typical Apache License, Version 2.0, statement follows.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+      https://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+
+The full text of the GNU GPL, Version 2, follows.
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 

--- a/LICENSE
+++ b/LICENSE
@@ -10,12 +10,17 @@ The files
 
   R/pubsub.R
   R/internal.R
+  R/rredis-misc.R: Idem
   src/libsock.c
   man/redisPublish.Rd
   man/redisSubscribe.Rd
   man/redisUnsubscribe.Rd
   man/redisMonitorChannels.Rd
   man/redisCmd.Rd
+  man/redisAuth.Rd
+  man/redisClose.Rd
+  man/redisConnect.Rd
+  man/redisZAdd.Rd
   tests/pubsub.R
 
 are included from the rredis package, and have been licensed under the

--- a/R/internal.R
+++ b/R/internal.R
@@ -25,17 +25,17 @@
   fd = NULL
   if(nodelay)
   {
-    fds <- .Call("OPEN_FD", PACKAGE="RcppRedis")
+    fds <- .Call(`_OPEN_FD`)
   }
   con <- socketConnection(host, port, open="a+b",
                           blocking=TRUE, timeout=timeout)
   if(nodelay)
   {
-    fd <- as.integer(setdiff(.Call("OPEN_FD", PACKAGE="RcppRedis"),fds))
+    fd <- as.integer(setdiff(.Call(`_OPEN_FD`),fds))
   }
   if(length(fd) > 0 && nodelay)
   {
-    Nagle <- vapply(fd, function(j) tryCatch(.Call("SOCK_NAGLE",j,1L,PACKAGE="RcppRedis"), error=function(e) 0L), 1L)
+    Nagle <- vapply(fd, function(j) tryCatch(.Call(`_SOCK_NAGLE`, j, 1L), error=function(e) 0L), 1L)
     if(!(any(Nagle==1)))
     {
       nodelay <- FALSE

--- a/R/internal.R
+++ b/R/internal.R
@@ -1,0 +1,288 @@
+# This file contains functions and environments used internally
+# by the rredis (and now RcppRedis) package (not exported in the namespace).
+
+.redisEnv <- new.env()
+.redisEnv$current <- .redisEnv
+
+.redis <- function(e)
+{
+  if(missing(e)) e = .redisEnv$current
+  if(!exists('con',envir=e))
+    stop('Not connected, try using redisConnect()')
+  e$con
+}
+
+.openConnection <- function(host, port, nodelay=FALSE,
+                            timeout=86400L, envir=rredis:::.redisEnv$current)
+{
+  stopifnot(is.character(host))
+  stopifnot(is.numeric(port))
+  stopifnot(is.logical(nodelay))
+  con <- envir$con
+  if(!is.null(con)) tryCatch(.closeConnection(con), error=invisible)
+# We track the file descriptor of the new connection in a crude way
+#  fds <- rownames(showConnections(all=TRUE)) # this doesn't work FYI
+  fd = NULL
+  if(nodelay)
+  {
+    fds <- .Call("OPEN_FD", PACKAGE="RcppRedis")
+  }
+  con <- socketConnection(host, port, open="a+b",
+                          blocking=TRUE, timeout=timeout)
+  if(nodelay)
+  {
+    fd <- as.integer(setdiff(.Call("OPEN_FD", PACKAGE="RcppRedis"),fds))
+  }
+  if(length(fd) > 0 && nodelay)
+  {
+    Nagle <- vapply(fd, function(j) tryCatch(.Call("SOCK_NAGLE",j,1L,PACKAGE="RcppRedis"), error=function(e) 0L), 1L)
+    if(!(any(Nagle==1)))
+    {
+      nodelay <- FALSE
+      warning("Unable to set nodelay.")
+    }
+  }
+# Stash state in the redis enivronment describing this connection:
+  assign('fd',fd,envir=envir)
+  assign('con',con,envir=envir)
+  assign('host',host,envir=envir)
+  assign('port',port,envir=envir)
+  assign('nodelay',nodelay,envir=envir)
+# Count is for pipelined communication, it keeps track of the number of
+# getResponse calls that are pending.
+  assign('count',0,envir=envir)
+  con
+}
+
+.closeConnection <- function(s)
+{
+  close(s)
+}
+
+# .redisError may be called by any function when a serious error occurs.
+# It will print an indicated error message, attempt to reset the current
+# Redis server connection, and signal the error.
+.redisError <- function(msg)
+{
+  env <- .redisEnv$current
+  con <- .redis()
+  .closeConnection(con)
+# May stop with an error here on connect fail
+  con <- .openConnection(host=env$host,
+                         port=env$port, nodelay=env$nodelay, envir=env)
+  stop(as.character(msg))
+}
+
+.redisPP <- function()
+{
+  # Ping-pong
+  .redisCmd(.raw('PING'))
+}
+
+.cerealize <- function(value)
+{
+  if("redis string value" %in% names(attributes(value)))
+  {
+    value <- tryCatch(charToRaw(value) , error=function(e) value)
+  }
+  if(!is.raw(value)) serialize(value,ascii=FALSE,connection=NULL)
+  else value
+}
+
+# Burn data in the RX buffer, used after interrupt conditions
+.burn <- function(e)
+{
+  con <- .redis()
+  count <- 0
+  while(socketSelect(list(con),timeout=1L) && count < 5)
+  {
+    readBin(con, raw(), 5000000L)
+    count <- count + 1
+  }
+  .redisError(e)
+}
+
+#
+# .raw converts single length character values to raw via charToRaw,
+# otherwise serializes the value
+#
+.raw <- function(word)
+{
+  if(is.raw(word)) word
+    if(is.character(word) && length(word) == 1) charToRaw(word)
+    else .cerealize(word)
+}
+
+# Expose the basic Redis interface to the user, interpreting single-length
+# character values as raw for user convenience (cf. the internal .redisCmd)
+redisCmd <- function(CMD, ..., raw=FALSE)
+{
+  a <- c(alist(),list(.raw(CMD)),
+         lapply(list(...), function(x)  .raw(x)))
+  if(raw) a <- c(a,raw=TRUE)
+  do.call('.redisCmd', a)
+}
+
+# .redisCmd corresponds to the Redis "multi bulk" protocol. It
+# expects an argument list of command elements. Arguments that
+# are not of type raw are serialized.
+# Examples:
+# .redisCmd(.raw('INFO'))
+# .redisCmd(.raw('SET'), .raw('X'), runif(5))
+#
+# We use match.call here instead of, for example, as.list() to try to
+# avoid making unnecessary copies of (potentially large) function arguments.
+#
+# TODO
+# We can further improve this by writing a shadow serialization routine that
+# quickly computes the length of a serialized object without serializing it.
+# Then, we could serialize directly to the connection, avoiding the temporary
+# copy.
+.redisCmd <- function(...)
+{
+  env <- .redisEnv$current
+  con <- .redis()
+# Check to see if a rename list exists and use it if it does...we also
+# define a little helper function to handle replacing the command.
+# The rename list must have the form:
+# list(OLDCOMMAND="NEWCOMMAND", SOME_OTHER_CMD="SOME_OTHER_NEW_CMD",...)
+  rep <- c()
+  if(exists("rename",envir=.redisEnv)) rep = get("rename",envir=.redisEnv)
+  f <- match.call()
+# Check for raw option (which means don't deserialize returned resuts)
+  raw <- FALSE
+  if(any("raw" %in% names(f)))
+  {
+    wr  <- which(names(f)=="raw")
+    raw <- f[[wr]]
+    f   <- f[-wr]
+  }
+  n <- length(f) - 1
+  hdr <- sprintf('*%d\r\n', n)
+  writeBin(.raw(hdr), con)
+  tryCatch({
+    for(j in seq_len(n)) {
+      if(j == 1)
+        v <- .renameCommand(eval(f[[j+1]],envir=sys.frame(-1)), rep)
+      else
+        v <- eval(f[[j+1]],envir=sys.frame(-1))
+      if(!is.raw(v)) v <- .cerealize(v)
+      l <- length(v)
+      hdr <- sprintf('$%d\r\n', l)
+      writeBin(c(.raw(hdr), v, .raw('\r\n')), con)
+    }
+  },
+    error=function(e) {.redisError("Invalid argument"); invisible()},
+    interrupt=function(e) .burn(e$message)
+  )
+
+  pipeline <- FALSE
+  if(exists('pipeline',envir=env)) pipeline <- get('pipeline',envir=env)
+  if(!pipeline)
+    return(.getResponse(raw=raw))
+  tryCatch(
+    env$count <- env$count + 1,
+    error = function(e) assign('count', 1, envir=env)
+  )
+  invisible()
+}
+
+.renameCommand <- function(x, rep)
+{
+  if(is.null(rep)) return(x)
+  v <- rawToChar(x)
+  if(v %in% names(rep)) return(charToRaw(rep[[v]]))
+  x
+}
+
+.getResponse <- function(raw=FALSE)
+{
+  env <- .redisEnv$current
+  tryCatch({
+    con <- .redis()
+    l <- readLines(con=con, n=1)
+
+    if(length(l)==0) .burn("Empty")
+    tryCatch(
+      env$count <- max(env$count - 1,0),
+      error = function(e) assign('count', 0, envir=env)
+    )
+    s <- substr(l, 1, 1)
+    if (nchar(l) < 2) {
+      if(s == "+") {
+        # '+' is a valid retrun message for at least one cmd (RANDOMKEY)
+        return("")
+      }
+      .burn("Invalid")
+    }
+    switch(s,
+         '-' = stop(substr(l,2,nchar(l))),
+         '+' = substr(l,2,nchar(l)),
+         ':' = {
+               if(!is.null(getOption('redis:num'))) return(as.numeric(substr(l,2,nchar(l))))
+               un <- substr(l,2,nchar(l))
+               attr(un, "redis string value") <- TRUE
+               un
+               },
+         '$' = {
+             n <- as.numeric(substr(l,2,nchar(l)))
+             if (n < 0) {
+               return(NULL)
+             }
+             dat <- tryCatch(readBin(con, 'raw', n=n),
+                             error=function(e) .redisError(e$message))
+             m <- length(dat)
+             if(m==n)
+             {
+               l <- readLines(con,n=1)
+               if(raw)
+                 return(dat)
+               else
+                 return(tryCatch(unserialize(dat),
+                         error=function(e)
+                         {
+                           un <- rawToChar(dat)
+                           attr(un, "redis string value") <- TRUE
+                           un
+                         }))
+             }
+# The message was not fully recieved in one pass for whatever reason.
+# We allocate a list to hold incremental messages and then concatenate it.
+# This perfromance enhancement was adapted from the Rbig server package,
+# written by Steve Weston and Pat Shields.
+             rlen <- 50
+             j <- 1
+             r <- vector('list',rlen)
+             r[j] <- list(dat)
+             while(m<n)
+             {
+               dat <- tryCatch(readBin(con, 'raw', n=(n-m)),
+                            error=function (e) .redisError(e$message))
+               j <- j + 1
+               if(j>rlen)
+               {
+                 rlen <- 2*rlen
+                 length(r) <- rlen
+               }
+               r[j] <- list(dat)
+               m <- m + length(dat)
+             }
+             l <- readLines(con,n=1)  # Trailing \r\n
+             length(r) <- j
+             if(raw)
+               do.call(c,r)
+             else
+               tryCatch(unserialize(do.call(c,r)),
+                      error=function(e) rawToChar(do.call(c,r)))
+           },
+         '*' = {
+           numVars <- as.integer(substr(l,2,nchar(l)))
+           if(numVars > 0L) {
+             replicate(numVars, .getResponse(raw=raw), simplify=FALSE)
+           } else NULL
+         },
+       stop('Unknown message type')
+    )
+    }, interrupt=function(e) .burn(e$message)
+  )
+}

--- a/R/pubsub.R
+++ b/R/pubsub.R
@@ -1,0 +1,48 @@
+`redisSubscribe` <- function(channels, pattern=FALSE)
+{
+  cmd <- 'SUBSCRIBE'
+  channels <- as.list(channels)
+  channels <- lapply(channels, charToRaw)
+  if(pattern) {
+    cmd <- 'PSUBSCRIBE'
+    if(length(channels)>1)
+      warning("Pattern subscription with multiple arguments")
+  }
+  x <- do.call('.redisCmd', c(list(.raw(cmd)),channels))
+  len <- length(channels) - 1L
+  if(len > 0L)
+    x <- c(x, replicate(len, .getResponse(), simplify=FALSE))
+  x
+}
+
+`redisUnsubscribe` <- function(channels, pattern=FALSE)
+{
+  cmd <- 'UNSUBSCRIBE'
+  channels <- as.list(channels)
+  channels <- lapply(channels, charToRaw)
+  if(pattern){
+    cmd <- 'PUNSUBSCRIBE'
+    if(length(channels)>1) warning("Pattern subscription with multiple arguments")
+  }
+  x <- do.call('.redisCmd', c(list(.raw(cmd)),channels))
+  len <- length(channels) - 1L
+  if(len > 0L)
+    x <- c(x, replicate(len, .getResponse(), simplify=FALSE))
+  x
+}
+
+`redisPublish` <- function(channel, message)
+{
+  do.call('.redisCmd', list(.raw('PUBLISH'),.raw(channel),message))
+}
+
+# Callback handler
+`redisMonitorChannels` <- function()
+{
+  x <- .getResponse()
+  if(length(x)!=3 && x[[1]] != "message") return(x)
+  if(exists(x[[2]],mode="function")) {
+    return(do.call(x[[2]],as.list(x[[3]])))
+  }
+  x
+}

--- a/R/rredis-misc.R
+++ b/R/rredis-misc.R
@@ -1,0 +1,43 @@
+redisConnect <-
+function(host='localhost', port=6379, password=NULL,
+         returnRef=FALSE, nodelay=TRUE, timeout=86400L, closeExisting=TRUE)
+{
+  if(closeExisting) tryCatch(redisClose(), error=invisible)
+  .redisEnv$current <- new.env()
+  assign('pipeline',FALSE,envir=.redisEnv$current)
+  con <- .openConnection(host=host, port=port, nodelay=nodelay, timeout=timeout, envir=.redisEnv$current)
+  if (!is.null(password)) tryCatch(redisAuth(password),
+    error=function(e) {
+      cat(paste('Error: ',e,'\n'))
+            .closeConnection(con);
+            rm(list='con',envir=.redisEnv$current)
+          })
+  tryCatch(.redisPP(),
+    error=function(e) {
+      cat(paste('Error: ',e,'\n'))
+            .closeConnection(con);
+            rm(list='con',envir=.redisEnv$current)
+          })
+  if(returnRef) return(.redisEnv$current)
+  invisible()
+}
+
+redisClose <-
+function(e)
+{
+  if(missing(e)) e = .redisEnv$current
+  con <- .redis(e)
+  .closeConnection(con)
+  remove(list='con',envir=e)
+}
+
+redisAuth <-
+function(pwd)
+{
+  .redisCmd(.raw('AUTH'), .raw(pwd))
+}
+
+# Redis ordered set functions
+redisZAdd <- function(key, score, member) {
+  .redisCmd(.raw('ZADD'), .raw(key), .raw(as.character(score)), .raw(member))
+}

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,17 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/rcppredis/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/rcppredis/issues/#1}{##1}}
 
+\section{Changes in version 0.1.12 (2022-01-xx)}{
+  \itemize{
+    \item Two simple C++11 feature remove needs for \pkg{BH} and \code{lexical_cast()}
+    (Dirk in \ghpr{45} addressing \ghit{44})
+    \item Redis pub/sub is now supported by importing the R functions
+    and C underpinning from \pkg{rredis} (Dirk in \ghpr{43})
+    \item Bryan Lewis is now a coauthor; the imported functions remain
+    licenced under the Apache License 2.0.
+  }
+}
+
 \section{Changes in version 0.1.11 (2021-06-26)}{
   \itemize{
     \item The CI setup was updated to use \code{run.sh} from

--- a/man/redisAuth.Rd
+++ b/man/redisAuth.Rd
@@ -1,0 +1,28 @@
+\name{redisAuth}
+\alias{redisAuth}
+\title{Redis authentication.}
+\description{Redis supports a trivially simple and insecure authentication 
+method. This function implements it.
+}
+\usage{
+redisAuth(pwd)
+}
+\arguments{
+  \item{pwd}{
+The (required) password.
+}
+}
+\details{
+If you use this function, it's probably a good idea to encrypt network
+traffic between Redis and its client with a program like stunnel.
+Otherwise, passwords are transmitted over the network in clear text.
+}
+\value{
+TRUE if sueccessful, FALSE otherwise.
+}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}

--- a/man/redisClose.Rd
+++ b/man/redisClose.Rd
@@ -1,0 +1,35 @@
+\name{redisClose}
+\alias{redisClose}
+\title{Close an open connection to a Redis server.}
+\description{The redisClose function closes any open connection to a Redis
+server.}
+\usage{
+redisClose(e)
+}
+\arguments{
+  \item{e}{(Optional) Redis context. The current context is used if e is not supplied.}
+}
+\details{A running instance of a Redis server is required.  }
+\value{Nothing is returned. Errors are displayed if the function fails to
+close the connection to the Redis server, or if the connection is invalid.
+}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}
+
+%% ~Make other sections like Warning with \section{Warning }{....} ~
+
+\seealso{
+\code{\link{redisConnect}}
+}
+\examples{
+\dontrun{
+redisConnect()
+redisSet('x',runif(5))
+redisGet('x')
+redisClose()
+}
+}

--- a/man/redisCmd.Rd
+++ b/man/redisCmd.Rd
@@ -1,0 +1,37 @@
+\name{redisCmd}
+\alias{redisCmd}
+\title{General Redis Interface Function}
+\description{Perform any Redis command.}
+\usage{
+redisCmd(CMD, ..., raw = FALSE)
+}
+\arguments{
+  \item{CMD}{
+The (required) Redis command (character string).
+}
+  \item{...}{
+Redis command arguments.
+}
+  \item{raw}{If TRUE, return results in raw byte form.}
+}
+\details{
+Use this low-level function to perform any Redis operation.
+The ... argument(s) not already in raw format will be
+converted to raw byte format, and non-character values
+will be serialized.
+}
+\value{
+Output from the Redis command--varies depending on command.
+}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}
+\examples{
+\dontrun{
+redisCmd('set','x',runif(5))
+redisCmd('get','x')
+}
+}

--- a/man/redisConnect.Rd
+++ b/man/redisConnect.Rd
@@ -1,0 +1,67 @@
+\name{redisConnect}
+\alias{redisConnect}
+\title{Connect to a Redis server.}
+\description{Connect to an available Redis server on the specified port.}
+\usage{
+redisConnect(host = "localhost", port = 6379, password = NULL,
+             returnRef = FALSE, nodelay=TRUE, timeout=86400L, closeExisting=TRUE)
+}
+\arguments{
+  \item{host}{The Redis server host name or inet address (optional, character). The default value is "localhost".}
+  \item{port}{The Redis port number (optional, numeric or integer). The default value is 6379L.}
+  \item{password}{Redis authentication password.}
+  \item{returnRef}{Set \code{returnRef=TRUE} to return the environment that contains the Redis connection state (see details). The default value is FALSE.}
+  \item{nodelay}{Set \code{nodelay=TRUE} to use TCP_NODELAY
+      (that is, to disbable the TCP Nagle algorithm). The default value is
+       \code{TRUE}, see the details below.}
+  \item{timeout}{Set the R connection timeout (in seconds).
+          Beware that some OSes may treat very large
+          values as zero: however the POSIX standard requires values up
+          to 31 days to be supported.}
+  \item{closeExisting}{Set to \code{FALSE} to keep any existing Redis connection open (for use with \code{setContext}).}
+}
+\details{
+A running instance of a Redis server is required.  Use \code{returnRef} to return
+the Redis connection state in an environment.  Then use the \code{redisSetContext}
+function to switch environment state and manage multiple open Redis
+connections.
+
+Set \code{nodelay=TRUE} to use the TCP_NODELY socket setting (disabling the TCP
+Nagle flow control algorithm) which can improve performance especially for
+rapid, non-pipelined small-sized transactions. We follow the convention of
+other popular Redis clients like the hiredis C library interface and use
+TCP_NODELAY as the default choice.
+
+Note that Redis pipelining can also increase performance:
+\code{redisSetPipeline(TRUE)} (q.v.).
+
+}
+
+\value{Nothing is returned by default. 
+Errors are displayed if the function fails to
+connect to the specified Redis server. Disconnect from a connected server
+with redisClose.
+
+If returnRef is set to TRUE and no error occurs, a list describing the 
+Redis connection will be returned. A future version of the package will
+use this feature to support multiple Redis connections with 
+the \code{attachRedis} function.
+}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}
+
+\seealso{
+\code{\link{redisClose}}
+}
+\examples{
+\dontrun{
+redisConnect()
+redisSet('x',runif(5))
+redisGet('x')
+redisClose()
+}
+}

--- a/man/redisMonitorChannels.Rd
+++ b/man/redisMonitorChannels.Rd
@@ -1,0 +1,67 @@
+\name{redisMonitorChannels}
+\alias{redisMonitorChannels}
+\title{redisMonitorChannels}
+\description{Subscribe to one or more Redis message channels.}
+\usage{
+redisMonitorChannels()
+}
+\details{(From the Redis.io documentation):
+\code{redisSubscribe}, \code{redisUnsubscribe} and \code{redisPublish}
+implement the Publish/Subscribe messaging paradigm where (citing Wikipedia)
+senders (publishers) are not programmed to send their messages to specific
+receivers (subscribers). Rather, published messages are characterized into
+channels, without knowledge of what (if any) subscribers there may be.
+Subscribers express interest in one or more channels, and only receive messages
+that are of interest, without knowledge of what (if any) publishers there are.
+
+The \code{redisMonitorChannels} function may be called repeatedly in an
+event loop to service messages on all subscribed channels. When a message
+is received, the \code{redisMonitorChannels} function will attempt to
+evaluate a callback function with same name as the channel, with the message
+as its single argument. If no such function can be found, the message is
+returned. See the help page for \code{redisGetResponse} for a description
+of the message format.
+
+WARNING: The \code{redisMonitorChannels} function blocks indefinitely until a 
+message is received.
+
+Use the lower-level \code{redisGetResponse} function to simply poll channels
+for messages without evaluating function callbacks.
+}
+\value{The result of an evaluated function callback message, or if
+no matching callback exists, the message.}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}
+\seealso{
+\code{\link{redisSubscribe}}
+\code{\link{redisPublish}}
+\code{\link{redisUnsubscribe}}
+\code{\link{redisMonitorChannels}}
+}
+\examples{
+\dontrun{
+redisConnect()
+# Define a callback function to process messages from channel 1:
+channel1 <- function(x) {
+  cat("Message received from channel 1: ",x,"\n")
+}
+# Define a callback function to process messages from channel 2:
+channel2 <- function(x) {
+  cat("Message received from channel 2: ",x,"\n")
+}
+redisSubscribe(c('channel1','channel2'))
+# Monitor channels for at least 1 minute:
+t1 <- proc.time()[[3]]
+while(proc.time()[[3]] - t1 < 60)
+{
+  redisMonitorChannels()
+  Sys.sleep(0.05)
+}
+redisUnsubscribe(c('channel1','channel2'))
+}
+}
+

--- a/man/redisPublish.Rd
+++ b/man/redisPublish.Rd
@@ -1,0 +1,50 @@
+\name{redisPublish}
+\alias{redisPublish}
+\title{redisPublish}
+\description{Publish data to a Redis message channel.}
+\usage{
+redisPublish(channel, message)
+}
+\arguments{
+  \item{channel}{The channel name (character).}
+  \item{message}{The message (any type, use RAW type for communication with
+                 non-R subscribers.}
+}
+\details{(From the Redis.io documentation):
+\code{redisSubscribe}, \code{redisUnsubscribe} and \code{redisPublish}
+implement the Publish/Subscribe messaging paradigm where (citing Wikipedia)
+senders (publishers) are not programmed to send their messages to specific
+receivers (subscribers). Rather, published messages are characterized into
+channels, without knowledge of what (if any) subscribers there may be.
+Subscribers express interest in one or more channels, and only receive messages
+that are of interest, without knowledge of what (if any) publishers there are.
+
+Use the Redis function \code{redisUnsubscribe} to unsubscribe from one or
+more channels. Service incoming messanges on the channels with either
+\code{redisGetResponse} or \code{redisMonitorChannels}.
+
+Use of any other Redis after \code{redisSubscribe} prior to calling
+\code{redisUnsubscribe} will result in an error.
+}
+\value{A list conforming to the Redis subscribe response message.
+Each subscribed channel corresponds to three list elements, the header
+'subscribe' followed by the channel name and a count indicating the total
+number of subscriptions.}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}
+\seealso{
+\code{\link{redisSubscribe}}
+\code{\link{redisUnsubscribe}}
+\code{\link{redisPublish}}
+\code{\link{redisMonitorChannels}}
+}
+\examples{
+\dontrun{
+redisConnect()
+redisPublish('channel1', charToRaw('A raw charachter data message example'))
+}
+}

--- a/man/redisSubscribe.Rd
+++ b/man/redisSubscribe.Rd
@@ -1,0 +1,67 @@
+\name{redisSubscribe}
+\alias{redisSubscribe}
+\title{redisSubscribe}
+\description{Subscribe to one or more Redis message channels.}
+\usage{
+redisSubscribe(channels, pattern=FALSE)
+}
+\arguments{
+  \item{channels}{A character vector or list of channel names to subscribe to.}
+  \item{pattern}{If TRUE, allow wildcard pattern matching in channel names,
+                 otherwise names indicate full channel names.}
+}
+\details{(From the Redis.io documentation):
+\code{redisSubscribe}, \code{redisUnsubscribe} and \code{redisPublish}
+implement the Publish/Subscribe messaging paradigm where (citing Wikipedia)
+senders (publishers) are not programmed to send their messages to specific
+receivers (subscribers). Rather, published messages are characterized into
+channels, without knowledge of what (if any) subscribers there may be.
+Subscribers express interest in one or more channels, and only receive messages
+that are of interest, without knowledge of what (if any) publishers there are.
+
+Use the Redis function \code{redisUnsubscribe} to unsubscribe from one or
+more channels. Service incoming messanges on the channels with either
+\code{redisGetResponse} or \code{redisMonitorChannels}.
+
+Use of any other Redis after \code{redisSubscribe} prior to calling
+\code{redisUnsubscribe} will result in an error.
+}
+\value{A list conforming to the Redis subscribe response message.
+Each subscribed channel corresponds to three list elements, the header
+'subscribe' followed by the channel name and a count indicating the total
+number of subscriptions.}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}
+\seealso{
+\code{\link{redisSubscribe}}
+\code{\link{redisPublish}}
+\code{\link{redisUnsubscribe}}
+\code{\link{redisMonitorChannels}}
+}
+\examples{
+\dontrun{
+redisConnect()
+# Define a callback function to process messages from channel 1:
+channel1 <- function(x) {
+  cat("Message received from channel 1: ",x,"\n")
+}
+# Define a callback function to process messages from channel 2:
+channel2 <- function(x) {
+  cat("Message received from channel 2: ",x,"\n")
+}
+redisSubscribe(c('channel1','channel2'))
+# Monitor channels for at least 1 minute:
+t1 <- proc.time()[[3]]
+while(proc.time()[[3]] - t1 < 60)
+{
+  redisMonitorChannels()
+  Sys.sleep(0.05)
+}
+redisUnsubscribe(c('channel1','channel2'))
+}
+}
+

--- a/man/redisUnsubscribe.Rd
+++ b/man/redisUnsubscribe.Rd
@@ -1,0 +1,67 @@
+\name{redisUnsubscribe}
+\alias{redisUnsubscribe}
+\title{redisUnsubscribe}
+\description{Subscribe to one or more Redis message channels.}
+\usage{
+redisUnsubscribe(channels, pattern=FALSE)
+}
+\arguments{
+  \item{channels}{A character vector or list of channel names to subscribe to.}
+  \item{pattern}{If TRUE, allow wildcard pattern matching in channel names,
+                 otherwise names indicate full channel names.}
+}
+\details{(From the Redis.io documentation):
+\code{redisSubscribe}, \code{redisUnsubscribe} and \code{redisPublish}
+implement the Publish/Subscribe messaging paradigm where (citing Wikipedia)
+senders (publishers) are not programmed to send their messages to specific
+receivers (subscribers). Rather, published messages are characterized into
+channels, without knowledge of what (if any) subscribers there may be.
+Subscribers express interest in one or more channels, and only receive messages
+that are of interest, without knowledge of what (if any) publishers there are.
+
+Use the Redis function \code{redisUnsubscribe} to unsubscribe from one or
+more channels. Service incoming messanges on the channels with either
+\code{redisGetResponse} or \code{redisMonitorChannels}.
+
+Use of any other Redis after \code{redisSubscribe} prior to calling
+\code{redisUnsubscribe} will result in an error.
+}
+\value{A list conforming to the Redis subscribe response message.
+Each subscribed channel corresponds to three list elements, the header
+element 'unsubscribe' followed by the channel name and a count indicating
+the total number of subscriptions.}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}
+\seealso{
+\code{\link{redisSubscribe}}
+\code{\link{redisUnsubscribe}}
+\code{\link{redisPublish}}
+\code{\link{redisMonitorChannels}}
+}
+\examples{
+\dontrun{
+redisConnect()
+# Define a callback function to process messages from channel 1:
+channel1 <- function(x) {
+  cat("Message received from channel 1: ",x,"\n")
+}
+# Define a callback function to process messages from channel 2:
+channel2 <- function(x) {
+  cat("Message received from channel 2: ",x,"\n")
+}
+redisSubscribe(c('channel1','channel2'))
+# Monitor channels for at least 1 minute:
+t1 <- proc.time()[[3]]
+while(proc.time()[[3]] - t1 < 60)
+{
+  redisMonitorChannels()
+  Sys.sleep(0.05)
+}
+redisUnsubscribe(c('channel1','channel2'))
+}
+}
+

--- a/man/redisZAdd.Rd
+++ b/man/redisZAdd.Rd
@@ -1,0 +1,29 @@
+\name{redisZAdd}
+\alias{redisZAdd}
+\title{
+redisZAdd
+}
+\description{
+Add an element to a Redis sorted set. Sorted sets order their elements
+by numeric weights.
+}
+\usage{
+redisZAdd(key, score, member)
+}
+\arguments{
+  \item{key}{
+The set name.
+}
+  \item{score}{
+The numeric score associated with the new element (member).
+}
+  \item{member}{
+The new object to add to the set.
+}
+}
+\references{
+http://redis.io/commands
+}
+\author{
+B. W. Lewis
+}

--- a/src/init.c
+++ b/src/init.c
@@ -9,9 +9,13 @@
 
 /* .Call calls */
 extern SEXP _rcpp_module_boot_Redis();
+extern SEXP _OPEN_FD();
+extern SEXP _SOCK_NAGLE(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_rcpp_module_boot_Redis", (DL_FUNC) &_rcpp_module_boot_Redis, 0},
+    {"_OPEN_FD",    (DL_FUNC) &_OPEN_FD,    0},
+    {"_SOCK_NAGLE", (DL_FUNC) &_SOCK_NAGLE, 2},
     {NULL, NULL, 0}
 };
 

--- a/src/libsock.c
+++ b/src/libsock.c
@@ -1,0 +1,94 @@
+/* Minimalist socket support functions to support setting TCP_NODELAY
+ * on socket connections and to infer socket descriptor for R connections.
+ *
+ * Copyright (C) 2016 Bryan W. Lewis
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdio.h>
+#ifdef WIN32
+#include <winsock2.h>
+#include <windows.h>
+#include <ws2tcpip.h>
+#else
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h> // TCP_NODELAY
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#define CHECKFD 8192
+#endif
+
+#include <R.h>
+#define USE_RINTERNALS
+#include <Rinternals.h>
+
+/* Crudely report open file descriptors on unix-like systems This is used to
+ * infer the active socket descriptor to apply TCP_NODELAY. This is a
+ * provisional approach. In the next package version, we'll define a new
+ * R_new_custom_connection object for rredis instead.
+ */
+SEXP OPEN_FD()
+{
+#ifdef WIN32
+  return R_NilValue;
+#else
+  SEXP ans;
+  struct stat s;
+  int j, k, l = 0;
+  int buf[CHECKFD];
+  for(j=0;j<CHECKFD;++j)
+  {
+    k = fstat(j,&s);
+    if(k>=0)
+    {
+      buf[l] = j;
+      l++;
+    }
+  }
+  PROTECT (ans = allocVector (INTSXP, l));
+  for(j=0;j<l;++j)
+  {
+    INTEGER(ans)[j] = buf[j];
+  }
+  UNPROTECT (1);
+  return ans;
+#endif
+}
+
+
+/* Set the Nagle socket option for socket S to an integer value VAL,
+ * returning the set value.
+ */
+SEXP SOCK_NAGLE(SEXP S, SEXP VAL)
+{
+  socklen_t len;
+  int val = INTEGER(VAL)[0];
+#ifdef WIN32
+  SOCKET s = (SOCKET)INTEGER(S)[0];
+#else
+  int s = INTEGER(S)[0];
+#endif
+  len = sizeof(val);
+  if(val>=0)
+  {
+    val = (int)(setsockopt(s, IPPROTO_TCP, TCP_NODELAY, (const void *)&val, len) == 0);
+  }
+  getsockopt(s, IPPROTO_TCP, TCP_NODELAY, (void *)&val, &len);
+  return ScalarInteger(val);
+}

--- a/src/libsock.c
+++ b/src/libsock.c
@@ -43,7 +43,7 @@
  * provisional approach. In the next package version, we'll define a new
  * R_new_custom_connection object for rredis instead.
  */
-SEXP OPEN_FD()
+SEXP _OPEN_FD()
 {
 #ifdef WIN32
   return R_NilValue;
@@ -75,7 +75,7 @@ SEXP OPEN_FD()
 /* Set the Nagle socket option for socket S to an integer value VAL,
  * returning the set value.
  */
-SEXP SOCK_NAGLE(SEXP S, SEXP VAL)
+SEXP _SOCK_NAGLE(SEXP S, SEXP VAL)
 {
   socklen_t len;
   int val = INTEGER(VAL)[0];

--- a/tests/pubsub.R
+++ b/tests/pubsub.R
@@ -1,0 +1,41 @@
+require(rredis)
+checkEquals <- function(x, y) if(!isTRUE(all.equal(x, y, check.attributes=FALSE))) stop()
+
+# redusMonitorChannels blocks forever until a message is received. We
+# use a background R process to send us some test messages.
+publisher <- function()
+
+{
+  Rbin <- paste(R.home(component="bin"), "R", sep="/")
+  cmd <- "require(rredis);redisConnect();Sys.sleep(2);redisPublish('channel1', charToRaw('1'));redisPublish('channel2', charToRaw('2'))"
+  args <- c("--slave", "-e", paste("\"", cmd, "\"", sep=""))
+  system(paste(c(Rbin, args), collapse=" "), intern=FALSE, wait=FALSE)
+}
+
+if(Sys.getenv("RunRRedisTests") == "yes")
+{
+  redisConnect()
+  redisFlushAll()
+  redisPublish("channel1", charToRaw("A raw charachter data message example"))
+  redisPublish("channel2", charToRaw("A raw charachter data message example"))
+
+  # Define a callback function to process messages from channel 1:
+  channel1 <- function(x) {
+    cat("Message received from channel 1: ",x,"\n")
+    checkEquals("1", x);
+  }
+  # Define a callback function to process messages from channel 2:
+  channel2 <- function(x) {
+    cat("Message received from channel 2: ",x,"\n")
+    checkEquals("2", x);
+  }
+  redisSubscribe(c('channel1','channel2'))
+  # Monitor channels for a few seconds until the background R process sends us
+  # some messages...
+  publisher()
+  redisMonitorChannels()
+  redisMonitorChannels()
+  redisUnsubscribe(c('channel1','channel2'))
+
+  redisFlushAll()
+}


### PR DESCRIPTION
As `rredis` may retire from CRAN one day, and no other simple package has pub/sub functionality we are bringing that functionality here following some earlier.

This comprises one main R file, along with a required R file with internal functions, one C file, five help pages and a test file.  As `rredis` is Apache 2.0 licensed we will keep those files under the same license and added language to that effect to file `DESCRIPTION` and `LICENSE` (which had so far been a copy of the GPL-2).  The aggregation will remain under that license.  This would appear to be the least-change way to go about it.


/CC @bwlewis 