### PR TITLE
subscribe, unsubscribe, psubscribe methods

### DIFF
--- a/man/listen.Rd
+++ b/man/listen.Rd
@@ -35,14 +35,14 @@ B. W. Lewis
 x <- new(Redis)
 y <- new(Redis)
 
-# Subscribe to the channels...
-x$exec("SUBSCRIBE channel1")
+# Subscribe to two example channels...
+x$subscribe(c("channel1", "channel2"))
 y$publish("channel1", pi)
 
 # Receive a message (warning, can block indefinitely)...
 listen(x)
 
 # Unsubscribe...
-x$exec("UNSUBSCRIBE channel1")
+x$unsubscribe(c("channel1", "channel2"))
 }
 }

--- a/man/redisMonitorChannels.Rd
+++ b/man/redisMonitorChannels.Rd
@@ -56,15 +56,13 @@ channel2 <- function(x) {
 }
 
 # Subscribe to the channels...
-x$exec("SUBSCRIBE channel1")
-x$exec("SUBSCRIBE channel2")
+x$subscribe(c("channel1", "channel2"))
 y$publish("channel2", pi)
 
 redisMonitorChannels(x)
 
 # Unsubscribe
-x$exec("UNSUBSCRIBE channel1")
-x$exec("UNSUBSCRIBE channel2")
+x$unsubscribe(c("channel1", "channel2"))
 }
 }
 


### PR DESCRIPTION
The new methods keep track of number of subscribed channels and avoid response problems associated with using exec.